### PR TITLE
Cherry-pick functional fixes from PR #5

### DIFF
--- a/main.js
+++ b/main.js
@@ -44,6 +44,7 @@ function determineStoragePath() {
 async function startBackend() {
   var backendDir = path.join(__dirname, 'backend')
   var dbFullPath = path.join(storagePath, 'app.db')
+  if (!fs.existsSync(storagePath)) fs.mkdirSync(storagePath, { recursive: true })
 
   backendProcess = spawn('dotnet', ['run', '--project', backendDir], {
     env: {
@@ -66,11 +67,18 @@ async function startBackend() {
     await new Promise(function(r) { setTimeout(r, 500) })
   }
   console.warn('[.NET] Timed out waiting for backend')
+  dialog.showErrorBox('Backend Error', 'Failed to start the backend service. Please restart the application.')
 }
 
 function stopBackend() {
   if (backendProcess && !backendProcess.killed) {
-    try { backendProcess.kill() } catch (e) {}
+    try {
+      if (process.platform === 'win32') {
+        require('child_process').execSync('taskkill /PID ' + backendProcess.pid + ' /T /F', { stdio: 'ignore' })
+      } else {
+        backendProcess.kill('SIGTERM')
+      }
+    } catch (e) {}
     backendProcess = null
   }
 }
@@ -98,6 +106,18 @@ function createWindow () {
   })
 }
 
+var gotTheLock = app.requestSingleInstanceLock()
+if (!gotTheLock) {
+  app.quit()
+} else {
+  app.on('second-instance', function() {
+    if (win) {
+      if (win.isMinimized()) win.restore()
+      win.focus()
+    }
+  })
+}
+
 app.whenReady().then(async () => {
   storagePath = determineStoragePath()
   await startBackend()
@@ -109,6 +129,7 @@ ipcMain.on('maximize', () => {
   win?.isMaximized() ? win.unmaximize() : win?.maximize()
 })
 ipcMain.on('close', () => win?.close())
+ipcMain.on('close-app', () => app.quit())
 
 ipcMain.handle('zoom-in', (e) => {
   var wc = e.sender

--- a/preload.js
+++ b/preload.js
@@ -32,7 +32,8 @@ var electronAPI = {
   backupRestore: (files) => ipcRenderer.invoke('backup:restore', files),
   backupGetInfo: () => ipcRenderer.invoke('backup:get-info'),
   backupGetDefaultPath: () => ipcRenderer.invoke('backup:get-default-path'),
-  backupOpenFolder: (folderPath) => ipcRenderer.invoke('backup:open-folder', folderPath)
+  backupOpenFolder: (folderPath) => ipcRenderer.invoke('backup:open-folder', folderPath),
+  closeApp: () => ipcRenderer.send('close-app')
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -36,8 +36,8 @@ async function showPage(name) {
   }
 }
 
-window.confirmSettingsSave = function() {
-  window.saveSettings();
+window.confirmSettingsSave = async function() {
+  await window.saveSettings();
   document.getElementById('settingsConfirmModal').style.display = 'none';
   document.getElementById('settingsModal').style.display = 'none';
   var target = _pendingNav;
@@ -66,6 +66,10 @@ document.addEventListener('keydown', function(e) {
   if (e.ctrlKey && (e.key === '=' || e.key === '+')) { e.preventDefault(); window.electronAPI.zoomIn(); }
   if (e.ctrlKey && e.key === '-') { e.preventDefault(); window.electronAPI.zoomOut(); }
   if (e.ctrlKey && e.key === '0') { e.preventDefault(); window.electronAPI.zoomReset(); }
+  if (e.ctrlKey && (e.key === 'p' || e.key === 'P')) { e.preventDefault(); showPage('pomodoro'); }
+  if (e.ctrlKey && (e.key === 's' || e.key === 'S')) { e.preventDefault(); if (window.openSettings) window.openSettings(); }
+  if (e.ctrlKey && (e.key === 'n' || e.key === 'N')) { e.preventDefault(); if (window.openAddTaskPopup) window.openAddTaskPopup(); }
+  if (e.ctrlKey && (e.key === 'q' || e.key === 'Q')) { e.preventDefault(); if (window.electronAPI) window.electronAPI.closeApp(); }
 });
 
 /* â”€â”€ Clock â”€â”€ */
@@ -176,12 +180,11 @@ window.closeWelcomeModal = async function() {
 window.checkForUpdates = function() {
   var btn = document.getElementById('checkUpdateBtn');
   if (btn) { btn.disabled = true; btn.textContent = 'Checking...'; }
-  var statusEl = document.getElementById('updateStatus');
+  var statusEl = document.getElementById('updateSettingsStatus');
   if (statusEl) { statusEl.style.display = 'block'; statusEl.textContent = 'Checking for updates...'; }
   window.electronAPI.checkForUpdates().then(function(available) {
     if (btn) { btn.disabled = false; btn.textContent = 'Search for Updates'; }
     if (available) {
-      // update-available event will fire automatically
     } else {
       if (statusEl) statusEl.textContent = 'You are up to date.';
       setTimeout(function() {
@@ -226,7 +229,7 @@ document.addEventListener('DOMContentLoaded', async function() {
 });
 window.addEventListener('load', function() {
   var elapsed = performance.now() - window._splashStart;
-  var delay = Math.max(0, 2000 - elapsed);
+  var delay = Math.max(0, 1500 - elapsed);
   setTimeout(function() {
     var splash = document.getElementById('app-splash');
     if (splash) { splash.style.opacity = '0'; splash.style.transition = 'opacity 0.6s'; setTimeout(function() { splash.style.display = 'none'; }, 600); }

--- a/src/js/components/goals/goals.js
+++ b/src/js/components/goals/goals.js
@@ -1,3 +1,11 @@
+function formatGoalDate(dateStr) {
+  if (!dateStr) return '-';
+  var parts = dateStr.split('-');
+  if (parts.length < 3) return dateStr;
+  var d = new Date(+parts[0], +parts[1] - 1, +parts[2]);
+  return d.toLocaleDateString();
+}
+
 var _editingGoalId = null;
 var _deleteGoalId = null;
 
@@ -176,8 +184,8 @@ function computeGoalProgress(goalId, childMap, taskMap, cache) {
 function goalCardHtml(g, progress) {
   var circumference = 2 * Math.PI * 30;
   var offset = circumference * (1 - (progress || 0) / 100);
-  var sd = g.startDate ? new Date(g.startDate).toLocaleDateString() : '';
-  var ed = g.endDate ? new Date(g.endDate).toLocaleDateString() : '';
+  var sd = formatGoalDate(g.startDate);
+  var ed = formatGoalDate(g.endDate);
   return '<div class="goal-card" style="border-left-color:' + g.color + '" data-goal-id="' + g.id + '">' +
     '<div class="goal-card-header">' +
       '<h3 class="goal-name">' + g.name + '</h3>' +
@@ -302,8 +310,8 @@ function openGoalDetailModal(goalId) {
         var progress = getProgress(g.id);
         var circumference = 2 * Math.PI * 34;
         var offset = circumference * (1 - progress / 100);
-        var sd = g.startDate ? new Date(g.startDate).toLocaleDateString() : '-';
-        var ed = g.endDate ? new Date(g.endDate).toLocaleDateString() : '-';
+        var sd = formatGoalDate(g.startDate);
+        var ed = formatGoalDate(g.endDate);
         var durText = g.duration ? g.duration + ' days' : '-';
         function renderChildTree(parentId, depth) {
           var kids = childMap[parentId] || [];

--- a/src/js/components/tasks/tasks.js
+++ b/src/js/components/tasks/tasks.js
@@ -1,3 +1,7 @@
+function newTaskId() {
+  return 'task_' + Date.now() + '_' + Math.random().toString(36).substring(2, 8);
+}
+
 var _selectedTaskGoalId = null;
 var _selectedPriority = 'Medium';
 var _sortBy = 'date-desc';
@@ -328,7 +332,7 @@ function addSubtask(parentId) {
   saveBtn.addEventListener('click', function() {
     var n = input.value.trim();
     if (n) {
-      var task = { id: 'task_' + Date.now(), name: n, parentTaskId: parentId, priority: _localPriority };
+      var task = { id: newTaskId(), name: n, parentTaskId: parentId, priority: _localPriority };
       window.db.createTask(task).then(function(result) { if (result) { removeModal(); renderTasks(); } });
     }
   });
@@ -380,14 +384,16 @@ function selectTaskGoal(el) {
 function saveTask() {
   var name = document.getElementById('task-name-input').value.trim();
   if (!name) return;
-  var task = { id: 'task_' + Date.now(), name: name, goalId: _selectedTaskGoalId, priority: _selectedPriority };
+  var task = { id: newTaskId(), name: name, goalId: _selectedTaskGoalId, priority: _selectedPriority };
   window.db.createTask(task).then(function(result) {
-    if (result === true) {
+    if (result) {
       document.getElementById('task-name-input').value = '';
       _selectedTaskGoalId = null;
       closeAddTaskPopup();
       renderTasks();
     }
+  }).catch(function(err) {
+    console.error('Failed to save task:', err);
   });
 }
 
@@ -477,9 +483,9 @@ function toggleGoalsTaskNode(e, id) {
 }
 
 function addTaskFromGoal(name, goalId) {
-  var task = { id: 'task_' + Date.now(), name: name, goalId: goalId };
+  var task = { id: newTaskId(), name: name, goalId: goalId };
   window.db.createTask(task).then(function(result) {
-    if (result === true) { renderTasks(); openGoalsTaskPopup(); }
+    if (result) { renderTasks(); openGoalsTaskPopup(); }
   });
 }
 

--- a/src/js/sessions.js
+++ b/src/js/sessions.js
@@ -719,7 +719,7 @@ async function getTodaySessions() {
    ───────────────────────────────────────────────────────── */
 async function renderSessionTimeline() {
 
-  var todaySessions = getTodaySessions();
+  var todaySessions = await getTodaySessions();
   var connector = '<div class="flex-shrink-0" style="width:24px;height:1px;background:#E5E7EB"></div>';
 
   /* ── Empty state: no sessions today ── */
@@ -849,7 +849,7 @@ async function renderSessionTimeline() {
 
 var sessionTimelineEditId = null;
 
-window.openSessionTimelineModal = function(sessionId) {
+window.openSessionTimelineModal = async function(sessionId) {
   sessionTimelineEditId = sessionId;
   var modal = document.getElementById('sessionTimelineModal');
   var input = document.getElementById('sessionTimelineTaskInput');
@@ -892,27 +892,6 @@ window.saveSessionTimeline = async function() {
   await renderSessionTimeline();
   window.closeSessionTimelineModal();
 };
-
-window.toggleTaskPopup = function() {
-  var toggle = document.getElementById('taskPopupToggle');
-  if (!toggle) return;
-  var currentlyOn = toggle.classList.contains('active');
-  if (currentlyOn) {
-    toggle.classList.remove('active');
-    await window.db.setSetting('showTaskPopupOnStart', 'false');
-  } else {
-    toggle.classList.add('active');
-    await window.db.setSetting('showTaskPopupOnStart', 'true');
-  }
-};
-
-(async function() {
-  var setting = await window.db.getSetting('showTaskPopupOnStart');
-  var toggle = document.getElementById('taskPopupToggle');
-  if (toggle && setting === 'false') {
-    toggle.classList.remove('active');
-  }
-})();
 
 document.addEventListener('click', function(e) {
   var modal = document.getElementById('sessionTimelineModal');

--- a/src/js/utils/audio.js
+++ b/src/js/utils/audio.js
@@ -9,21 +9,22 @@ function getAudio(path) {
   return audioCache[path];
 }
 
-function playSound(soundName, options = {}) {
-  const enabled = window.db?.getSetting?.('playPomoSound') !== 'false';
-  if (!enabled) return;
-
-  const volume = parseFloat(window.db?.getSetting?.('pomoSoundVolume')) || 1.0;
-  const basePath = 'assets/App Sounds/';
-  const path = basePath + soundName;
-
+async function playSound(soundName, options = {}) {
   try {
-    const audio = getAudio(path);
+    var enabled = await window.db.getSetting('playPomoSound');
+    if (enabled === 'false') return;
+
+    var volumeStr = await window.db.getSetting('pomoSoundVolume');
+    var volume = parseFloat(volumeStr) || 1.0;
+    var basePath = 'assets/App Sounds/';
+    var path = basePath + soundName;
+
+    var audio = getAudio(path);
     audio.volume = Math.max(0, Math.min(1, volume));
     audio.currentTime = 0;
-    const promise = audio.play();
+    var promise = audio.play();
     if (promise) {
-      promise.catch(err => console.warn('Audio play failed:', err.message));
+      promise.catch(function(err) { console.warn('Audio play failed:', err.message); });
     }
   } catch (e) {
     console.warn('Sound error:', e.message);


### PR DESCRIPTION
Cherry-picks 10 non-CSS fixes from @mhrshi123's PR #5:

- **main.js**: Single instance lock, create data dir before backend spawn, kill process tree via taskkill, error dialog on backend failure
- **Keyboard shortcuts**: Ctrl+P (pomodoro), Ctrl+S (settings), Ctrl+N (new task), Ctrl+Q (quit app) — wired via preload closeApp IPC
- **Splash**: Reduced timeout from 2000ms → 1500ms
- **confirmSettingsSave**: Now async, properly awaits saveSettings()
- **checkForUpdates**: Uses updateSettingsStatus element (avoids conflict with update modal's updateStatus)
- **tasks.js**: newTaskId() with random suffix to prevent duplicate-key crashes; error handling in saveTask
- **goals.js**: formatGoalDate() for timezone-safe date rendering (fixes negative-offset TZs)
- **audio.js**: playSound now async with proper await on getSetting calls
- **sessions.js**: Fixed missing await on getTodaySessions(); removed duplicate toggleTaskPopup conflicting with settings.js; made openSessionTimelineModal properly async

Co-authored-by: mhrshi123 <mhrshi123@users.noreply.github.com>