### PR TITLE
fix: keyboard shortcuts intercepted by Electron (Ctrl+P/S/N/Q)

### DIFF
--- a/main.js
+++ b/main.js
@@ -104,6 +104,16 @@ function createWindow () {
   win.loadFile('src/index.html').then(function() {
     autoUpdater.checkForUpdates()
   })
+
+  win.webContents.on('before-input-event', function(e, input) {
+    if (!input.control) return
+    switch (input.key.toLowerCase()) {
+      case 'p': e.preventDefault(); win.webContents.send('shortcut', 'pomodoro'); break
+      case 's': e.preventDefault(); win.webContents.send('shortcut', 'settings'); break
+      case 'n': e.preventDefault(); win.webContents.send('shortcut', 'new-task'); break
+      case 'q': e.preventDefault(); app.quit(); break
+    }
+  })
 }
 
 var gotTheLock = app.requestSingleInstanceLock()

--- a/preload.js
+++ b/preload.js
@@ -33,7 +33,10 @@ var electronAPI = {
   backupGetInfo: () => ipcRenderer.invoke('backup:get-info'),
   backupGetDefaultPath: () => ipcRenderer.invoke('backup:get-default-path'),
   backupOpenFolder: (folderPath) => ipcRenderer.invoke('backup:open-folder', folderPath),
-  closeApp: () => ipcRenderer.send('close-app')
+  closeApp: () => ipcRenderer.send('close-app'),
+  onShortcut: (callback) => {
+    ipcRenderer.on('shortcut', (_, action) => callback(action))
+  }
 }
 
 contextBridge.exposeInMainWorld('electronAPI', electronAPI)

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -66,10 +66,13 @@ document.addEventListener('keydown', function(e) {
   if (e.ctrlKey && (e.key === '=' || e.key === '+')) { e.preventDefault(); window.electronAPI.zoomIn(); }
   if (e.ctrlKey && e.key === '-') { e.preventDefault(); window.electronAPI.zoomOut(); }
   if (e.ctrlKey && e.key === '0') { e.preventDefault(); window.electronAPI.zoomReset(); }
-  if (e.ctrlKey && (e.key === 'p' || e.key === 'P')) { e.preventDefault(); showPage('pomodoro'); }
-  if (e.ctrlKey && (e.key === 's' || e.key === 'S')) { e.preventDefault(); if (window.openSettings) window.openSettings(); }
-  if (e.ctrlKey && (e.key === 'n' || e.key === 'N')) { e.preventDefault(); if (window.openAddTaskPopup) window.openAddTaskPopup(); }
-  if (e.ctrlKey && (e.key === 'q' || e.key === 'Q')) { e.preventDefault(); if (window.electronAPI) window.electronAPI.closeApp(); }
+});
+window.electronAPI.onShortcut(function(action) {
+  switch (action) {
+    case 'pomodoro': showPage('pomodoro'); break;
+    case 'settings': if (window.openSettings) openSettings(); break;
+    case 'new-task': if (window.openAddTaskPopup) openAddTaskPopup(); break;
+  }
 });
 
 /* â”€â”€ Clock â”€â”€ */


### PR DESCRIPTION
Electron/Chromium intercepts Ctrl+P/S/N/Q before the renderer's keydown handler, so \preventDefault()\ was insufficient.

**Fix**: Use \win.webContents.on('before-input-event')\ in main process to intercept shortcuts before Chromium processes them, then forward via IPC.

Co-authored-by: mhrshi123 <mhrshi123@users.noreply.github.com>