### PR TITLE
fix: remove default Electron menu so Ctrl+P shortcut works

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron')
+const { app, BrowserWindow, ipcMain, dialog, shell, Menu } = require('electron')
 const path = require('path')
 const fs = require('fs')
 const { spawn } = require('child_process')
@@ -84,6 +84,7 @@ function stopBackend() {
 }
 
 function createWindow () {
+  Menu.setApplicationMenu(Menu.buildFromTemplate([]))
   win = new BrowserWindow({
     width: 1200,
     height: 800,


### PR DESCRIPTION
Electron's default menu has CmdOrCtrl+P as the Print accelerator which fires before our before-input-event handler can intercept it.

Fix: set Menu.setApplicationMenu(Menu.buildFromTemplate([])) to disable all default accelerators.