### PR TITLE
Release v2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ backend/jamrah.db-wal
 test-backend.db
 test-backend.db-shm
 test-backend.db-wal
+
+# Published .NET backend
+backend/publish/
+

--- a/main.js
+++ b/main.js
@@ -42,11 +42,19 @@ function determineStoragePath() {
 }
 
 async function startBackend() {
-  var backendDir = path.join(__dirname, 'backend')
   var dbFullPath = path.join(storagePath, 'app.db')
   if (!fs.existsSync(storagePath)) fs.mkdirSync(storagePath, { recursive: true })
 
-  backendProcess = spawn('dotnet', ['run', '--project', backendDir], {
+  var backendCmd, backendArgs
+  if (app.isPackaged) {
+    backendCmd = path.join(process.resourcesPath, 'backend', 'Jamrah.Backend.exe')
+    backendArgs = []
+  } else {
+    backendCmd = 'dotnet'
+    backendArgs = ['run', '--project', path.join(__dirname, 'backend')]
+  }
+
+  backendProcess = spawn(backendCmd, backendArgs, {
     env: {
       ...process.env,
       ASPNETCORE_URLS: 'http://localhost:5200',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamrah",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "description": "Jamrah جَــمْــرَه — ember of productivity. Pomodoro timer, habits tracker & more",
   "main": "main.js",
   "author": "AhmMed29",
@@ -8,6 +8,7 @@
   "scripts": {
     "postinstall": "npx @electron/rebuild",
     "start": "electron .",
+    "prebuild": "dotnet publish backend/Jamrah.Backend.csproj -c Release -o backend/publish --self-contained -r win-x64",
     "build": "electron-builder",
     "dist": "electron-builder --win"
   },
@@ -23,6 +24,13 @@
       "database.js",
       "Jamrah-Icon.png",
       "src/**/*"
+    ],
+    "extraResources": [
+      {
+        "from": "backend/publish",
+        "to": "backend",
+        "filter": ["**/*"]
+      }
     ],
     "win": {
       "target": "nsis",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -91,7 +91,7 @@ updateClock();
 setInterval(updateClock, 1000);
 
 /* â”€â”€ Update system (electron-updater) â”€â”€ */
-var APP_VERSION = '1.3.3';
+var APP_VERSION = '2.0.0';
 var updateData = null;
 var updateDownloaded = false;
 


### PR DESCRIPTION
## Release v2.0.0

### Key changes
- Redesigned pomodoro controls (7-button row, hover-reveal, session counter)
- Keyboard shortcuts: Ctrl+P/S/N/Q
- Production backend: published .NET exe instead of dotnet run
- Backend auto-starts with app (packaged in extraResources)
- Fixed: timezone-safe goal dates
- Fixed: duplicate toggleTaskPopup removed
- Fixed: async audio playback
- Fixed: task ID collision with random suffix
- Splash screen faster (1.5s)
- Single instance lock