### PR TITLE
fix: add splash screen fallback timeout for mobile

### DIFF
--- a/mobile/src/js/mobile-bootstrap.js
+++ b/mobile/src/js/mobile-bootstrap.js
@@ -45,4 +45,14 @@
   // Hide floating dock
   var dock = document.getElementById('floating-dock')
   if (dock) dock.style.display = 'none'
+
+  // Fallback: force-hide splash after 3s (in case load event never fires)
+  setTimeout(function() {
+    var splash = document.getElementById('app-splash')
+    if (splash && splash.style.display !== 'none') {
+      splash.style.opacity = '0'
+      splash.style.transition = 'opacity 0.3s'
+      setTimeout(function() { splash.style.display = 'none' }, 300)
+    }
+  }, 3000)
 })()


### PR DESCRIPTION
Splash screen was stuck on mobile because the `load` event can be delayed/blocked by external CDN resources (Tailwind, Google Fonts, Font Awesome) when the device has no/slow internet.

Fix: Add a 3-second `setTimeout` fallback in `mobile-bootstrap.js` that force-hides the splash by fading it out, so the app is usable even if the `load` event never fires.
