### PR TITLE
fix: invalidate frontend cache when EXE version changes

### DIFF
--- a/main.js
+++ b/main.js
@@ -124,6 +124,7 @@ function createWindow () {
       win.webContents.send('backend-error', _backendStartFailed)
     }
   })
+  if (app.isPackaged) updater.invalidateCacheIfNeeded()
   var frontendHtml = app.isPackaged
     ? (updater.getFrontendIndexPath() || path.join(__dirname, 'src', 'index.html'))
     : path.join(__dirname, 'src', 'index.html')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jamrah",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Jamrah جَــمْــرَه — ember of productivity. Pomodoro timer, habits tracker & more",
   "main": "main.js",
   "author": "AhmMed29",

--- a/update.json
+++ b/update.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.1",
-  "downloadUrl": "https://github.com/AhmMed29/jamrah/releases/download/v3.0.1/Jamrah.Setup.3.0.1.exe",
+  "version": "3.0.2",
+  "downloadUrl": "https://github.com/AhmMed29/jamrah/releases/download/v3.0.2/Jamrah.Setup.3.0.2.exe",
   "releaseNotes": "🔥 v3.0.0 — The Session Timeline Release\n\nMajor:\n- Session Timeline Side Box — hour-by-hour timeline, day nav, inline editing, session notes\n- Redesigned Sidebar — single toggle button, overlay mode with backdrop\n\nNew Features:\n- Session name popup on timer start\n- Calendar timeline view (day & week)\n- Goals tag editor popup\n- Frontend auto-update system\n- Page placement preferences\n- Welcome popup with full app overview (one-time)\n\nUI & UX:\n- Timer interaction fixes — sync toggleTimer, no stop button delay\n- Minimal mode on first load — no layout shift\n- Session side box spacing & timeline dots fix\n- Phase words positioned correctly\n- Habits & Tasks improvements\n\nBug Fixes:\n- Stop button no longer restarts timer\n- Settings button delay eliminated\n- Updater.js bundled in electron-builder"
 }

--- a/updater.js
+++ b/updater.js
@@ -12,6 +12,20 @@ function psExec(cmd) {
   return spawnSync('powershell', ['-NoProfile', '-EncodedCommand', b], { stdio: 'pipe', windowsHide: true })
 }
 
+exports.invalidateCacheIfNeeded = function() {
+  var dir = frontendDir()
+  var vf = path.join(dir, 'version.txt')
+  if (!fs.existsSync(dir) || !fs.existsSync(vf)) return false
+
+  var cachedVer = fs.readFileSync(vf, 'utf-8').trim()
+  var pkg = require(path.join(__dirname, 'package.json'))
+  if (cmpVer(pkg.version, cachedVer) > 0) {
+    try { fs.rmSync(dir, { recursive: true }) } catch {}
+    return true
+  }
+  return false
+}
+
 exports.getFrontendIndexPath = function() {
   var fp = path.join(frontendDir(), 'index.html')
   return fs.existsSync(fp) ? fp : null


### PR DESCRIPTION
Adds \invalidateCacheIfNeeded()\ to updater.js — compares app version (package.json) with cached frontend version (version.txt). If EXE is newer, clears the cache so bundled frontend runs.